### PR TITLE
Remove the space in the title if it ends with a space

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -91,7 +91,7 @@ class ModuleInterface:
         track_name = track_data.get('title')[:-1] if track_data.get('title').endswith(' ') else track_data.get('title')
         track_name += f' ({track_data.get("version")})' if track_data.get("version") else ''
 
-        album_name = album_data.get('title')
+        album_name = album_data.get('title')[:-1] if album_name.get('title').endswith(' ') else album_data.get('title')
         album_name += f' ({album_data.get("version")})' if album_data.get("version") else ''
 
         return TrackInfo(

--- a/interface.py
+++ b/interface.py
@@ -88,7 +88,7 @@ class ModuleInterface:
             bitrate = int((stream_data['sampling_rate'] * 1000 * stream_data['bit_depth'] * 2) // 1000)
 
         # track and album title fix to include version tag
-        track_name = track_data.get('title')
+        track_name = track_data.get('title')[:-1] if track_data.get('title').endswith(' ') else track_data.get('title')
         track_name += f' ({track_data.get("version")})' if track_data.get("version") else ''
 
         album_name = album_data.get('title')


### PR DESCRIPTION
I saw that sometimes Qobuz will return a space in the title, which got annoying once a special name was added. This is just a quick little way to fix it. 

ex: https://open.qobuz.com/track/145286588