### PR TITLE
Fix 'format_id' error for nonstreamable tracks

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -48,7 +48,7 @@ class ModuleInterface:
         token = self.session.login(email, password)
         self.session.auth_token = token
         self.module_controller.temporary_settings_controller.set('token', token)
-    
+
     def get_track_info(self, track_id, quality_tier: QualityEnum, codec_options: CodecOptions, data={}):
         track_data = data[track_id] if track_id in data else self.session.get_track(track_id)
         album_data = track_data['album']
@@ -101,6 +101,8 @@ class ModuleInterface:
         bitrate = 320
         if stream_data.get('format_id') in {6, 7, 27}:
             bitrate = int((stream_data['sampling_rate'] * 1000 * stream_data['bit_depth'] * 2) // 1000)
+        elif not stream_data.get('format_id'):
+            bitrate = stream_data.get('format_id')
 
         # track and album title fix to include version tag
         track_name = f"{track_data.get('work')} - " if track_data.get('work') else ""
@@ -123,7 +125,7 @@ class ModuleInterface:
             explicit = track_data['parental_warning'],
             cover_url = album_data['image']['large'].split('_')[0] + '_org.jpg',
             tags = tags,
-            codec = CodecEnum.FLAC if stream_data['format_id'] in {6, 7, 27} else CodecEnum.MP3,
+            codec = CodecEnum.FLAC if stream_data.get('format_id') in {6, 7, 27} else CodecEnum.NONE if not stream_data.get('format_id') else CodecEnum.MP3,
             duration = track_data.get('duration'),
             credits_extra_kwargs = {'data': {track_id: track_data}},
             download_extra_kwargs = {'url': stream_data.get('url')},


### PR DESCRIPTION
This was originally fixed with Pull request #13, but the line
```python
codec = CodecEnum.FLAC if stream_data.get('format_id') in {6, 7, 27} else CodecEnum.MP3,
```
was reverted in the master at some point (I am not sure when).

I restored the fix and also introduced additional testing to display Codec as `Error` instead of `MP3`, as well as setting bitrate `empty`.

For reference, here is an album to be released on May 12, 2023: [https://www.qobuz.com/us-en/album/ocra-palladian/cz4wrf40u88za](https://www.qobuz.com/us-en/album/ocra-palladian/cz4wrf40u88za) 

The output appears like so:

![image](https://user-images.githubusercontent.com/128258751/228371031-9bfce3f3-49f4-4394-a23b-2d1b2e6b4e68.png)

On a side note..

It's interesting that the `stream_data` json for the tracks in this yet to be released album lists `"sampling_rate": 88.2,`,  yet the album is indicated on the website to be available in `16-Bit CD Quality
44.1 kHz - Stereo`

The `stream_data` json also indicates that the release is not available in hi-res:
```json
{
    "track_id": 195361085,
    "duration": 317,
    "restrictions": [
        {
            "code": "FormatRestrictedByFormatAvailability"
        },
        {
            "code": "TrackRestrictedByPurchaseCredentials"
        },
        {
            "code": "SampleRestrictedByRightHolders"
        }
    ],
    "sampling_rate": 88.2,
    "bit_depth": 16
}
```
The `track_data` json:
```json
{
    "maximum_bit_depth": 16,
    "copyright": "2023 Loci Records 2023 Loci Records",
    "audio_info": {
        "replaygain_track_peak": 0.96875,
        "replaygain_track_gain": -8.4
    },
    "performer": {
        "name": "PALLADIAN",
        "id": 7781094
    },
    "work": null,
    "isrc": "QZ5FN2363737",
    "title": "Mirage",
    "version": null,
    "duration": 317,
    "parental_warning": false,
    "track_number": 8,
    "maximum_channel_count": 2,
    "id": 195361085,
    "media_number": 1,
    "maximum_sampling_rate": 44.1,
    "release_date_original": null,
    "release_date_download": null,
    "release_date_stream": null,
    "purchasable": false,
    "streamable": false,
    "previewable": false,
    "sampleable": false,
    "downloadable": false,
    "displayable": true,
    "purchasable_at": 1683806400,
    "streamable_at": 1683806400,
    "hires": false,
    "hires_streamable": false,
```

My thought is I wonder if Qobuz sometimes receives hi-res material, but only makes it available in cd quality per `FormatRestrictedByFormatAvailability` flag.